### PR TITLE
Add NPC and item persistence

### DIFF
--- a/src/main/java/org/zyz/childhoodreverie/entity/InventoryEntity.java
+++ b/src/main/java/org/zyz/childhoodreverie/entity/InventoryEntity.java
@@ -23,9 +23,9 @@ public class InventoryEntity {
     private String playerId;
 
     /**
-     * 物品名称
+     * 物品 ID
      */
-    private String itemName;
+    private String itemId;
 
     /**
      * 数量

--- a/src/main/java/org/zyz/childhoodreverie/entity/ItemEntity.java
+++ b/src/main/java/org/zyz/childhoodreverie/entity/ItemEntity.java
@@ -1,0 +1,22 @@
+package org.zyz.childhoodreverie.entity;
+
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+/**
+ * Item definition entity
+ */
+@Data
+@TableName("item_info")
+public class ItemEntity {
+    /** item unique ID */
+    @TableId
+    private String itemId;
+    /** display name */
+    private String name;
+    /** item type */
+    private String type;
+    /** item description */
+    private String description;
+}

--- a/src/main/java/org/zyz/childhoodreverie/entity/NpcEntity.java
+++ b/src/main/java/org/zyz/childhoodreverie/entity/NpcEntity.java
@@ -1,0 +1,22 @@
+package org.zyz.childhoodreverie.entity;
+
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+
+/**
+ * NPC basic info entity
+ */
+@Data
+@TableName("npc_info")
+public class NpcEntity {
+    /** NPC unique ID */
+    @TableId
+    private String npcId;
+    /** NPC name */
+    private String name;
+    /** level */
+    private int level;
+    /** current location */
+    private String location;
+}

--- a/src/main/java/org/zyz/childhoodreverie/mapper/ItemMapper.java
+++ b/src/main/java/org/zyz/childhoodreverie/mapper/ItemMapper.java
@@ -1,0 +1,20 @@
+package org.zyz.childhoodreverie.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Mapper;
+import org.zyz.childhoodreverie.entity.ItemEntity;
+
+/**
+ * Item mapper
+ */
+@Mapper
+public interface ItemMapper extends BaseMapper<ItemEntity> {
+    /**
+     * clear table
+     */
+    @Delete("""
+        DELETE FROM item_info WHERE 1=1
+    """)
+    void clear();
+}

--- a/src/main/java/org/zyz/childhoodreverie/mapper/NpcMapper.java
+++ b/src/main/java/org/zyz/childhoodreverie/mapper/NpcMapper.java
@@ -1,0 +1,20 @@
+package org.zyz.childhoodreverie.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import org.apache.ibatis.annotations.Delete;
+import org.apache.ibatis.annotations.Mapper;
+import org.zyz.childhoodreverie.entity.NpcEntity;
+
+/**
+ * NPC info mapper
+ */
+@Mapper
+public interface NpcMapper extends BaseMapper<NpcEntity> {
+    /**
+     * clear table
+     */
+    @Delete("""
+        DELETE FROM npc_info WHERE 1=1
+    """)
+    void clear();
+}

--- a/src/main/java/org/zyz/childhoodreverie/service/StorageService.java
+++ b/src/main/java/org/zyz/childhoodreverie/service/StorageService.java
@@ -22,6 +22,10 @@ public class StorageService {
     @Autowired
     private InventoryMapper inventoryMapper;
     @Autowired
+    private NpcMapper npcMapper;
+    @Autowired
+    private ItemMapper itemMapper;
+    @Autowired
     private WorldStateMapper worldStateMapper;
     @Autowired
     private EventLogMapper eventLogMapper;
@@ -42,6 +46,24 @@ public class StorageService {
 
     public PlayerEntity getPlayer(String playerId) {
         return playerMapper.selectById(playerId);
+    }
+
+    // NPC basic info
+    public void saveNpc(NpcEntity npc) {
+        npcMapper.insert(npc);
+    }
+
+    public NpcEntity getNpc(String npcId) {
+        return npcMapper.selectById(npcId);
+    }
+
+    // Item definitions
+    public void saveItem(ItemEntity item) {
+        itemMapper.insert(item);
+    }
+
+    public ItemEntity getItem(String itemId) {
+        return itemMapper.selectById(itemId);
     }
 
     // 背包操作


### PR DESCRIPTION
## Summary
- add `NpcEntity` and `ItemEntity`
- update `InventoryEntity` to store `itemId`
- create `NpcMapper` and `ItemMapper`
- extend `StorageService` with new CRUD helpers

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6860fe055608832ebce6dd7f03119bfb