### PR TITLE
Add controllers for inventory and npc info

### DIFF
--- a/src/main/java/org/zyz/childhoodreverie/controller/InventoryController.java
+++ b/src/main/java/org/zyz/childhoodreverie/controller/InventoryController.java
@@ -1,0 +1,73 @@
+package org.zyz.childhoodreverie.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+import org.zyz.childhoodreverie.entity.InventoryEntity;
+import org.zyz.childhoodreverie.service.StorageService;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 玩家背包增删改查接口
+ */
+@RestController
+@RequestMapping("/inventory")
+public class InventoryController {
+
+    @Autowired
+    private StorageService storageService;
+
+    /**
+     * 查询玩家背包
+     */
+    @GetMapping("/{playerId}")
+    public List<InventoryEntity> getInventory(@PathVariable String playerId) {
+        return storageService.getInventory(playerId);
+    }
+
+    /**
+     * 新增背包物品
+     */
+    @PostMapping("/{playerId}")
+    public InventoryEntity addItem(@PathVariable String playerId,
+                                   @RequestBody Map<String, String> req) {
+        InventoryEntity item = new InventoryEntity();
+        item.setPlayerId(playerId);
+        item.setItemId(req.get("itemId"));
+        item.setQuantity(Integer.parseInt(req.getOrDefault("quantity", "1")));
+        storageService.addInventoryItem(item);
+        return item;
+    }
+
+    /**
+     * 更新背包物品
+     */
+    @PutMapping("/{playerId}/{id}")
+    public InventoryEntity updateItem(@PathVariable String playerId,
+                                      @PathVariable Long id,
+                                      @RequestBody Map<String, String> req) {
+        InventoryEntity item = storageService.getInventoryItem(id);
+        if (item != null && item.getPlayerId().equals(playerId)) {
+            if (req.containsKey("itemId")) {
+                item.setItemId(req.get("itemId"));
+            }
+            if (req.containsKey("quantity")) {
+                item.setQuantity(Integer.parseInt(req.get("quantity")));
+            }
+            storageService.updateInventoryItem(item);
+        }
+        return item;
+    }
+
+    /**
+     * 删除背包物品
+     */
+    @DeleteMapping("/{playerId}/{id}")
+    public void deleteItem(@PathVariable String playerId, @PathVariable Long id) {
+        InventoryEntity item = storageService.getInventoryItem(id);
+        if (item != null && item.getPlayerId().equals(playerId)) {
+            storageService.deleteInventoryItem(id);
+        }
+    }
+}

--- a/src/main/java/org/zyz/childhoodreverie/controller/NpcBaseController.java
+++ b/src/main/java/org/zyz/childhoodreverie/controller/NpcBaseController.java
@@ -1,0 +1,63 @@
+package org.zyz.childhoodreverie.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+import org.zyz.childhoodreverie.entity.NpcEntity;
+import org.zyz.childhoodreverie.service.StorageService;
+
+import java.util.Map;
+
+/**
+ * NPC 基本信息管理接口
+ */
+@RestController
+@RequestMapping("/npc/base")
+public class NpcBaseController {
+
+    @Autowired
+    private StorageService storageService;
+
+    /**
+     * 创建 NPC
+     */
+    @PostMapping
+    public NpcEntity createNpc(@RequestBody Map<String, String> req) {
+        NpcEntity npc = new NpcEntity();
+        npc.setNpcId(req.get("npcId"));
+        npc.setName(req.get("name"));
+        npc.setLevel(Integer.parseInt(req.getOrDefault("level", "1")));
+        npc.setLocation(req.getOrDefault("location", ""));
+        storageService.saveNpc(npc);
+        return npc;
+    }
+
+    /**
+     * 查询 NPC 信息
+     */
+    @GetMapping("/{npcId}")
+    public NpcEntity getNpc(@PathVariable String npcId) {
+        return storageService.getNpc(npcId);
+    }
+
+    /**
+     * 更新 NPC 信息
+     */
+    @PutMapping("/{npcId}")
+    public NpcEntity updateNpc(@PathVariable String npcId,
+                               @RequestBody Map<String, String> req) {
+        NpcEntity npc = storageService.getNpc(npcId);
+        if (npc != null) {
+            if (req.containsKey("name")) {
+                npc.setName(req.get("name"));
+            }
+            if (req.containsKey("level")) {
+                npc.setLevel(Integer.parseInt(req.get("level")));
+            }
+            if (req.containsKey("location")) {
+                npc.setLocation(req.get("location"));
+            }
+            storageService.updateNpc(npc);
+        }
+        return npc;
+    }
+}

--- a/src/main/java/org/zyz/childhoodreverie/service/StorageService.java
+++ b/src/main/java/org/zyz/childhoodreverie/service/StorageService.java
@@ -60,6 +60,10 @@ public class StorageService {
         return npcMapper.selectById(npcId);
     }
 
+    public void updateNpc(NpcEntity npc) {
+        npcMapper.updateById(npc);
+    }
+
     // Item definitions
     public void saveItem(ItemEntity item) {
         itemMapper.insert(item);
@@ -86,6 +90,22 @@ public class StorageService {
                         .eq("player_id", items.get(0).getPlayerId())
         );
         items.forEach(inventoryMapper::insert);
+    }
+
+    public void addInventoryItem(InventoryEntity item) {
+        inventoryMapper.insert(item);
+    }
+
+    public InventoryEntity getInventoryItem(Long id) {
+        return inventoryMapper.selectById(id);
+    }
+
+    public void updateInventoryItem(InventoryEntity item) {
+        inventoryMapper.updateById(item);
+    }
+
+    public void deleteInventoryItem(Long id) {
+        inventoryMapper.deleteById(id);
     }
 
     // 世界状态操作


### PR DESCRIPTION
## Summary
- add `InventoryController` with CRUD endpoints
- add `NpcBaseController` for NPC base data management
- extend `StorageService` with inventory helpers and NPC update

## Testing
- `mvn test` *(fails: Could not download dependencies)*
- `mvn -DskipTests=true package` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686149999120832e9033dc3f2b94ee2b